### PR TITLE
Redesign chat landing layout and thread rail grouping

### DIFF
--- a/apps/web/app/app/chat/components/chat-shell.tsx
+++ b/apps/web/app/app/chat/components/chat-shell.tsx
@@ -36,6 +36,11 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Separator } from "@/components/ui/separator";
+import {
+  Collapsible,
+  CollapsibleTrigger,
+  CollapsibleContent,
+} from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
@@ -46,11 +51,11 @@ import {
   MessageQuestionIcon,
   MoreHorizontalIcon,
 } from "@hugeicons/core-free-icons";
+import { ChevronDownIcon } from "lucide-react";
 import {
   mockThreads,
   mockProjects,
   type ChatThread,
-  type ChatProject,
 } from "./mock-data";
 
 function formatTimeAgo(timestamp: number): string {
@@ -67,7 +72,6 @@ function formatTimeAgo(timestamp: number): string {
 interface ThreadRowProps {
   thread: ChatThread;
   isActive: boolean;
-  project?: ChatProject;
   isEditing: boolean;
   editingTitle: string;
   onEditTitleChange: (value: string) => void;
@@ -81,7 +85,6 @@ interface ThreadRowProps {
 function ThreadRow({
   thread,
   isActive,
-  project,
   isEditing,
   editingTitle,
   onEditTitleChange,
@@ -133,14 +136,6 @@ function ThreadRow({
           <span className="text-xs text-muted-foreground tabular-nums">
             {formatTimeAgo(thread.updatedAt)}
           </span>
-          {project && (
-            <Badge
-              variant="outline"
-              className="rounded-none text-[10px] h-4 px-1"
-            >
-              {project.icon} {project.title}
-            </Badge>
-          )}
         </div>
       </div>
 
@@ -250,13 +245,12 @@ export function ChatShell({ children }: ChatShellProps) {
       t.snippet.toLowerCase().includes(searchQuery.toLowerCase()),
   );
 
-  const pinnedThreads = filteredThreads.filter((t) => t.pinned);
-  const recentThreads = filteredThreads.filter((t) => !t.pinned);
-
-  const getProject = (thread: ChatThread) =>
-    thread.projectId
-      ? mockProjects.find((p) => p.id === thread.projectId)
-      : undefined;
+  const pinnedThreads = filteredThreads.filter(
+    (t) => t.pinned && !t.projectId,
+  );
+  const recentThreads = filteredThreads.filter(
+    (t) => !t.pinned && !t.projectId,
+  );
 
   const handleStartEdit = (thread: ChatThread) => {
     setEditingThreadId(thread.id);
@@ -301,10 +295,6 @@ export function ChatShell({ children }: ChatShellProps) {
       ),
     }))
     .filter((group) => group.threads.length > 0);
-
-  const unassignedThreads = filteredThreads.filter(
-    (thread) => !thread.projectId,
-  );
 
   return (
     <>
@@ -429,7 +419,6 @@ export function ChatShell({ children }: ChatShellProps) {
                             key={thread.id}
                             thread={thread}
                             isActive={thread.id === activeThreadId}
-                            project={getProject(thread)}
                             isEditing={editingThreadId === thread.id}
                             editingTitle={editingTitle}
                             onEditTitleChange={setEditingTitle}
@@ -464,7 +453,6 @@ export function ChatShell({ children }: ChatShellProps) {
                             key={thread.id}
                             thread={thread}
                             isActive={thread.id === activeThreadId}
-                            project={getProject(thread)}
                             isEditing={editingThreadId === thread.id}
                             editingTitle={editingTitle}
                             onEditTitleChange={setEditingTitle}
@@ -479,41 +467,41 @@ export function ChatShell({ children }: ChatShellProps) {
                     </div>
                   )}
 
-                  {(groupedByProject.length > 0 ||
-                    unassignedThreads.length > 0) && (
+                  {groupedByProject.length > 0 && (
                     <>
                       <Separator className="bg-sidebar-border" />
                       <div className="space-y-3">
                         <div className="flex items-center gap-2 px-1">
                           <span className="text-xs font-medium text-muted-foreground">
-                            By project
+                            Projects
                           </span>
                         </div>
-
-                        <div className="space-y-4">
+                        <div className="space-y-2">
                           {groupedByProject.map((group) => (
-                            <div key={group.project.id} className="space-y-2">
-                              <div className="flex items-center gap-2 px-1">
-                                <span className="text-xs">
-                                  {group.project.icon}
-                                </span>
-                                <span className="text-xs font-medium text-muted-foreground">
+                            <Collapsible
+                              key={group.project.id}
+                              defaultOpen
+                              className="rounded-none border border-sidebar-border/60 bg-sidebar/40"
+                            >
+                              <CollapsibleTrigger className="group flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-xs font-medium text-muted-foreground transition-colors hover:bg-accent/40">
+                                <span className="flex items-center gap-2">
+                                  <span>{group.project.icon}</span>
                                   {group.project.title}
+                                  <Badge
+                                    variant="secondary"
+                                    className="rounded-none text-[10px] h-4 px-1"
+                                  >
+                                    {group.threads.length}
+                                  </Badge>
                                 </span>
-                                <Badge
-                                  variant="secondary"
-                                  className="rounded-none text-[10px] h-4 px-1"
-                                >
-                                  {group.threads.length}
-                                </Badge>
-                              </div>
-                              <div className="space-y-1">
+                                <ChevronDownIcon className="size-4 transition-transform group-data-[state=open]:rotate-180" />
+                              </CollapsibleTrigger>
+                              <CollapsibleContent className="space-y-1 px-1 pb-2">
                                 {group.threads.map((thread) => (
                                   <ThreadRow
                                     key={thread.id}
                                     thread={thread}
                                     isActive={thread.id === activeThreadId}
-                                    project={getProject(thread)}
                                     isEditing={editingThreadId === thread.id}
                                     editingTitle={editingTitle}
                                     onEditTitleChange={setEditingTitle}
@@ -528,48 +516,9 @@ export function ChatShell({ children }: ChatShellProps) {
                                     }
                                   />
                                 ))}
-                              </div>
-                            </div>
+                              </CollapsibleContent>
+                            </Collapsible>
                           ))}
-
-                          {unassignedThreads.length > 0 && (
-                            <div className="space-y-2">
-                              <div className="flex items-center gap-2 px-1">
-                                <span className="text-xs">📌</span>
-                                <span className="text-xs font-medium text-muted-foreground">
-                                  No project
-                                </span>
-                                <Badge
-                                  variant="secondary"
-                                  className="rounded-none text-[10px] h-4 px-1"
-                                >
-                                  {unassignedThreads.length}
-                                </Badge>
-                              </div>
-                              <div className="space-y-1">
-                                {unassignedThreads.map((thread) => (
-                                  <ThreadRow
-                                    key={thread.id}
-                                    thread={thread}
-                                    isActive={thread.id === activeThreadId}
-                                    project={getProject(thread)}
-                                    isEditing={editingThreadId === thread.id}
-                                    editingTitle={editingTitle}
-                                    onEditTitleChange={setEditingTitle}
-                                    onStartEdit={() => handleStartEdit(thread)}
-                                    onCancelEdit={handleCancelEdit}
-                                    onCommitEdit={handleCommitEdit}
-                                    onTogglePin={() =>
-                                      handleTogglePin(thread.id)
-                                    }
-                                    onDeleteRequest={() =>
-                                      setDeleteThreadId(thread.id)
-                                    }
-                                  />
-                                ))}
-                              </div>
-                            </div>
-                          )}
                         </div>
                       </div>
                     </>

--- a/apps/web/app/app/chat/page.tsx
+++ b/apps/web/app/app/chat/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useRef } from "react";
 import { useRouter } from "next/navigation";
-import { Badge } from "@/components/ui/badge";
 import {
   Combobox,
   ComboboxInput,
@@ -35,7 +34,6 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
   GlobalIcon,
-  FolderManagementIcon,
   Image01Icon,
   MessageQuestionIcon,
   PlusSignIcon,
@@ -68,21 +66,11 @@ const SUGGESTIONS = [
     description: "Outline milestones and deliverables",
     value: "Create a project plan",
   },
-  {
-    title: "Draft a task list",
-    description: "Capture quick to-dos from a note",
-    value: "Draft a task list",
-  },
-  {
-    title: "Summarize project status",
-    description: "Turn updates into a short brief",
-    value: "Summarize project status",
-  },
 ];
 
 function SuggestionGrid({ onSelect }: { onSelect: (suggestion: string) => void }) {
   return (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
       {SUGGESTIONS.map((suggestion) => (
         <button
           key={suggestion.value}
@@ -90,12 +78,11 @@ function SuggestionGrid({ onSelect }: { onSelect: (suggestion: string) => void }
           onClick={() => onSelect(suggestion.value)}
           className="text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         >
-          <Card
-            className="border-border/60 hover:border-foreground/20 hover:bg-accent/40 transition-colors"
-            size="sm"
-          >
-            <CardHeader className="space-y-1">
-              <CardTitle className="text-sm">{suggestion.title}</CardTitle>
+          <Card className="border-border/60 hover:border-foreground/20 hover:bg-accent/40 transition-colors">
+            <CardHeader className="space-y-1.5">
+              <CardTitle className="text-sm font-medium">
+                {suggestion.title}
+              </CardTitle>
               <CardDescription className="text-xs">
                 {suggestion.description}
               </CardDescription>
@@ -133,25 +120,26 @@ function ComposerWithScope() {
       {/* Center content */}
       <div className="flex-1">
         <div className="flex flex-col items-center justify-center min-h-full px-6 py-12">
-          {/* Headline */}
-          <div className="text-center mb-8 max-w-2xl">
-            <div className="inline-flex items-center justify-center size-10 rounded-none border bg-background mb-4">
+          <div className="text-center max-w-2xl">
+            <div className="inline-flex items-center justify-center size-11 rounded-none border bg-background mb-5">
               <HugeiconsIcon
                 icon={MessageQuestionIcon}
                 className="size-5"
                 strokeWidth={2}
               />
             </div>
-            <h1 className="text-2xl font-medium mb-2">
-              Chat with your workspace
+            <h1 className="text-3xl font-medium mb-3">
+              What can I help you build?
             </h1>
             <p className="text-sm text-muted-foreground">
-              Ask questions, plan work, and turn ideas into tasks.
+              Start a conversation or choose a prompt to shape your next task.
             </p>
           </div>
 
-          {/* Suggestions */}
-          <div className="w-full max-w-3xl">
+          <div className="w-full max-w-2xl mt-10">
+            <p className="text-xs font-medium text-muted-foreground mb-3 text-center">
+              Suggested prompts
+            </p>
             <SuggestionGrid onSelect={handleSuggestionSelect} />
           </div>
         </div>
@@ -160,104 +148,79 @@ function ComposerWithScope() {
       {/* Composer - Fixed at bottom */}
       <div className="shrink-0 border-t bg-background/80 backdrop-blur p-4 pb-[env(safe-area-inset-bottom)]">
         <div className="max-w-3xl mx-auto">
-          {/* Scope control */}
-          <div className="flex items-center justify-between gap-3 mb-2 px-1">
-            <span className="text-xs text-muted-foreground">Scope</span>
-            <div className="w-full max-w-[240px]">
-              <Combobox>
-                <ComboboxInput
-                  placeholder="Select scope..."
-                  className="h-8 text-xs"
-                  showTrigger
-                  value={scopeLabel}
-                  readOnly
-                />
-                <ComboboxContent>
-                  <ComboboxList>
-                    <ComboboxItem
-                      onClick={() => setScope({ type: "all" })}
-                      className="flex items-center gap-2"
-                    >
+          <PromptInput onSubmit={handleSubmit}>
+            <PromptInputHeader>
+              <div className="flex w-full items-center justify-between gap-3">
+                <PromptInputTools>
+                  <PromptInputActionMenu>
+                    <PromptInputActionMenuTrigger>
                       <HugeiconsIcon
-                        icon={GlobalIcon}
+                        icon={PlusSignIcon}
                         className="size-4"
                         strokeWidth={2}
                       />
-                      All workspace
-                    </ComboboxItem>
-                    <ComboboxEmpty />
-                  </ComboboxList>
-                  <div className="px-2 py-1 text-xs font-medium text-muted-foreground">
-                    Projects
-                  </div>
-                  <ComboboxList>
-                    {mockProjects.map((project) => (
-                      <ComboboxItem
-                        key={project.id}
-                        onClick={() =>
-                          setScope({
-                            type: "project",
-                            projectId: project.id,
-                            projectName: project.title,
-                          })
-                        }
-                        className="flex items-center gap-2"
-                      >
-                        <span>{project.icon}</span>
-                        {project.title}
-                      </ComboboxItem>
-                    ))}
-                  </ComboboxList>
-                </ComboboxContent>
-              </Combobox>
-            </div>
-            <Badge variant="outline" className="rounded-none text-xs">
-              {scope.type === "all" ? (
-                <>
-                  <HugeiconsIcon
-                    icon={GlobalIcon}
-                    className="size-3 mr-1"
-                    strokeWidth={2}
-                  />
-                  All workspace
-                </>
-              ) : (
-                <>
-                  <HugeiconsIcon
-                    icon={FolderManagementIcon}
-                    className="size-3 mr-1"
-                    strokeWidth={2}
-                  />
-                  {mockProjects.find((p) => p.id === scope.projectId)?.icon}{" "}
-                  {scope.projectName}
-                </>
-              )}
-            </Badge>
-          </div>
-
-          <PromptInput onSubmit={handleSubmit}>
-            <PromptInputHeader>
-              <PromptInputTools>
-                <PromptInputActionMenu>
-                  <PromptInputActionMenuTrigger>
+                    </PromptInputActionMenuTrigger>
+                    <PromptInputActionMenuContent>
+                      <PromptInputActionAddAttachments />
+                    </PromptInputActionMenuContent>
+                  </PromptInputActionMenu>
+                  <PromptInputButton variant="ghost" size="icon-sm">
                     <HugeiconsIcon
-                      icon={PlusSignIcon}
+                      icon={Image01Icon}
                       className="size-4"
                       strokeWidth={2}
                     />
-                  </PromptInputActionMenuTrigger>
-                  <PromptInputActionMenuContent>
-                    <PromptInputActionAddAttachments />
-                  </PromptInputActionMenuContent>
-                </PromptInputActionMenu>
-                <PromptInputButton variant="ghost" size="icon-sm">
-                  <HugeiconsIcon
-                    icon={Image01Icon}
-                    className="size-4"
-                    strokeWidth={2}
-                  />
-                </PromptInputButton>
-              </PromptInputTools>
+                  </PromptInputButton>
+                </PromptInputTools>
+                <div className="w-full max-w-[200px]">
+                  <Combobox>
+                    <ComboboxInput
+                      placeholder="Select scope..."
+                      className="h-7 text-xs"
+                      showTrigger
+                      value={scopeLabel}
+                      readOnly
+                    />
+                    <ComboboxContent>
+                      <ComboboxList>
+                        <ComboboxItem
+                          onClick={() => setScope({ type: "all" })}
+                          className="flex items-center gap-2"
+                        >
+                          <HugeiconsIcon
+                            icon={GlobalIcon}
+                            className="size-4"
+                            strokeWidth={2}
+                          />
+                          All workspace
+                        </ComboboxItem>
+                        <ComboboxEmpty />
+                      </ComboboxList>
+                      <div className="px-2 py-1 text-xs font-medium text-muted-foreground">
+                        Projects
+                      </div>
+                      <ComboboxList>
+                        {mockProjects.map((project) => (
+                          <ComboboxItem
+                            key={project.id}
+                            onClick={() =>
+                              setScope({
+                                type: "project",
+                                projectId: project.id,
+                                projectName: project.title,
+                              })
+                            }
+                            className="flex items-center gap-2"
+                          >
+                            <span>{project.icon}</span>
+                            {project.title}
+                          </ComboboxItem>
+                        ))}
+                      </ComboboxList>
+                    </ComboboxContent>
+                  </Combobox>
+                </div>
+              </div>
             </PromptInputHeader>
 
             <PromptInputTextarea


### PR DESCRIPTION
### Motivation
- Simplify and calm the chat landing experience so the composer and suggested prompts are the primary focus. 
- Consolidate scope controls into the prompt header to reduce redundant UI and make the composer more compact. 
- Improve thread rail organization by grouping project threads and allowing them to be collapsed for cleaner navigation.

### Description
- Redesigned chat landing copy and layout in `apps/web/app/app/chat/page.tsx`, updated hero icon size, headline, description, suggestion list styling, and reduced suggestion grid columns.  
- Moved scope selection into the `PromptInput` header and replaced the prior separate scope UI with a compact `Combobox` inside the prompt header, adjusting related imports and button arrangement.  
- Reworked thread rail in `apps/web/app/app/chat/components/chat-shell.tsx` so pinned/recent lists exclude project-scoped threads, and project threads are displayed inside `Collapsible` groups with a `ChevronDownIcon` trigger.  
- Removed per-thread project badge from `ThreadRow` and cleaned up unused code/imports related to the old grouping and scope display.

### Testing
- Ran `npm run lint`, which failed due to `turbo` not being available in the environment.  
- Attempted `npm run dev:web`, which could not start for the same reason (`turbo` not found).  
- Files edited and staged: `apps/web/app/app/chat/components/chat-shell.tsx` and `apps/web/app/app/chat/page.tsx`, and changes were committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698208e588b48321a7291a4bdf1594db)