### PR TITLE
docs(web): add docs/architecture and refresh web README + UI specs

### DIFF
--- a/apps/web/AI_CHAT_UI_SPEC.md
+++ b/apps/web/AI_CHAT_UI_SPEC.md
@@ -16,6 +16,13 @@
 - Empty states: `Empty` component with `border-dashed`
 - Mobile-first with route-driven navigation
 
+## Implementation Notes (Current Code)
+
+- Left rail state is managed in `app/app/chat/components/chat-shell.tsx` using mock thread data.
+- Thread editing, pinning, and deletion are implemented against local state only.
+- `/app/chat` creates temporary thread IDs (prefixed with `temp-`) and routes to `/app/chat/[threadId]`.
+- Conversation content is mocked via `app/app/chat/components/mock-data.ts`.
+
 ## Layout Architecture
 
 ### Desktop (md+): 2-Pane Split
@@ -437,5 +444,5 @@ From AI elements:
 
 ---
 
-**Status**: Phase 0 — Specification Locked
-**Next**: Phase 1 — Routing + Shared Chat Shell
+**Status**: UI implemented with mock state (no Convex persistence yet)
+**Next**: Replace mock threads/messages with Convex-backed conversations

--- a/apps/web/NOTES_UI_SPEC.md
+++ b/apps/web/NOTES_UI_SPEC.md
@@ -16,6 +16,12 @@
 - Empty states: `Empty` component with `border-dashed`
 - Mobile-first sheet pattern: bottom `Sheet` for editor (like TaskDetailsSheet)
 
+## Implementation Notes (Current Code)
+
+- Notes data lives in local component state with URL param syncing for `note`, `project`, `view`, and `q`.
+- Project list and note list are mocked in the page module for now.
+- Editor save state is simulated client-side (no persistence).
+
 ## Layout Architecture
 
 ### Desktop (md+): 2-Pane Split

--- a/apps/web/PHASE1_COMPLETE.md
+++ b/apps/web/PHASE1_COMPLETE.md
@@ -1,27 +1,21 @@
-Phase 1 — Routing + Shared Chat Shell
+Chat UI Snapshot (Current)
 
-✅ **New Files Created:**
+**Routes Implemented**
 
-- `apps/web/app/app/chat/layout.tsx` — Shared chat shell wrapper
-- `apps/web/app/app/chat/components/chat-shell.tsx` — Left rail with thread list, search, pinned/recent sections
-- `apps/web/app/app/chat/page.tsx` — New chat landing with scope control + prompt chips + composer
-- `apps/web/app/app/chat/[threadId]/page.tsx` — Thread conversation view with messages + composer
+- `/app/chat` for new chat landing
+- `/app/chat/[threadId]` for conversation view
 
-✅ **Bug Fixes:**
+**UI Features Implemented**
 
-- Fixed `radix-ui` import errors in `hover-card.tsx` and `button-group.tsx`
-- Installed missing `@radix-ui/react-hover-card` package
-
-**Features Implemented:**
-
-- Route-per-thread architecture: `/app/chat` and `/app/chat/[threadId]`
-- 2-pane layout (340px left rail + flex main panel)
-- Left rail with New chat button, search, Pinned + Recent thread sections
-- Thread rows with title, snippet, time, project badge, pin icon
-- Active thread highlighting based on current route
-- New chat landing: Scope picker (All workspace / Projects), 9 prompt chips in 3 groups, bottom-anchored composer
-- Thread view: Header with mobile back button + scope badge, conversation log, composer
+- Shared chat shell layout with left rail and main panel
+- Thread list with search, pinned, recent, and project grouping
+- Inline rename, pin/unpin, and delete actions (local state only)
+- New chat landing with prompt suggestions and composer
+- Conversation view with mock messages, scope badges, and composer tools
 - Not-found state for invalid thread IDs
-- Mobile responsive with route-driven navigation
+- Mobile routing behavior (rail hides on thread route)
 
-**Next:** Phase 2 — Add real interaction with mock data (thread selection, search filtering, empty states)
+**Data Status**
+
+- Thread and message data are mocked in `app/app/chat/components/mock-data.ts`
+- Conversations are not persisted to Convex yet

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -44,6 +44,14 @@ Non-goals for v1:
 - Semantic vector search (planned v1.1+)
 - Full reminders engine (planned after schedule model is solid)
 
+## Current Implementation Snapshot
+
+- Convex-backed data: inbox, tasks, projects, tags, subtasks, onboarding, settings.
+- UI-only (mock state): notes and AI chat.
+- Marketing routes: landing page and roadmap.
+
+Detailed docs live in [`docs/`](./docs/README.md).
+
 ## Roadmap
 
 ### Phase 1 — Foundation (Week 1)
@@ -88,7 +96,7 @@ Non-goals for v1:
 
 ## Requirements
 
-- Node.js 20+
+- Node.js 25+
 - npm
 - A Convex deployment
 

--- a/apps/web/convex/README.md
+++ b/apps/web/convex/README.md
@@ -1,90 +1,22 @@
-# Welcome to your Convex functions directory!
+# Convex Functions for Taskflow Web
 
-Write your Convex functions here.
-See https://docs.convex.dev/functions for more.
+This directory powers the Convex backend for `apps/web`.
 
-A query function that takes two arguments looks like:
+## Key Modules
 
-```ts
-// convex/myFunctions.ts
-import { query } from "./_generated/server";
-import { v } from "convex/values";
+- `schema.ts`: Database schema for tasks, projects, tags, inbox items, and profiles.
+- `tasks.ts`: Task CRUD, filters, and scheduling behavior.
+- `projects.ts`: Project CRUD plus archive and detail fetches.
+- `inbox.ts`: Inbox capture and conversion flows.
+- `subtasks.ts`: Subtask CRUD and completion toggles.
+- `tags.ts`: Tag creation and list helpers.
+- `preferences.ts`: User preference updates for onboarding and settings.
+- `profiles.ts`: User profile reads and updates.
+- `users.ts`: User identity helpers tied to Convex auth.
+- `auth.ts` + `auth.config.ts`: Convex Auth configuration (Password provider).
 
-export const myQueryFunction = query({
-  // Validators for arguments.
-  args: {
-    first: v.number(),
-    second: v.string(),
-  },
+## Development Notes
 
-  // Function implementation.
-  handler: async (ctx, args) => {
-    // Read the database as many times as you need here.
-    // See https://docs.convex.dev/database/reading-data.
-    const documents = await ctx.db.query("tablename").collect();
-
-    // Arguments passed from the client are properties of the args object.
-    console.log(args.first, args.second);
-
-    // Write arbitrary JavaScript here: filter, aggregate, build derived data,
-    // remove non-public properties, or create new objects.
-    return documents;
-  },
-});
-```
-
-Using this query function in a React component looks like:
-
-```ts
-const data = useQuery(api.myFunctions.myQueryFunction, {
-  first: 10,
-  second: "hello",
-});
-```
-
-A mutation function looks like:
-
-```ts
-// convex/myFunctions.ts
-import { mutation } from "./_generated/server";
-import { v } from "convex/values";
-
-export const myMutationFunction = mutation({
-  // Validators for arguments.
-  args: {
-    first: v.string(),
-    second: v.string(),
-  },
-
-  // Function implementation.
-  handler: async (ctx, args) => {
-    // Insert or modify documents in the database here.
-    // Mutations can also read from the database like queries.
-    // See https://docs.convex.dev/database/writing-data.
-    const message = { body: args.first, author: args.second };
-    const id = await ctx.db.insert("messages", message);
-
-    // Optionally, return a value from your mutation.
-    return await ctx.db.get("messages", id);
-  },
-});
-```
-
-Using this mutation function in a React component looks like:
-
-```ts
-const mutation = useMutation(api.myFunctions.myMutationFunction);
-function handleButtonPress() {
-  // fire and forget, the most common way to use mutations
-  mutation({ first: "Hello!", second: "me" });
-  // OR
-  // use the result once the mutation has completed
-  mutation({ first: "Hello!", second: "me" }).then((result) =>
-    console.log(result),
-  );
-}
-```
-
-Use the Convex CLI to push your functions to a deployment. See everything
-the Convex CLI can do by running `npx convex -h` in your project root
-directory. To learn more, launch the docs with `npx convex docs`.
+- Run `npm run dev:backend --workspace=@taskflow/web` to start the Convex dev server.
+- Use `npx convex dev` from `apps/web` for CLI tools and type generation.
+- Generated types live in `convex/_generated` and should not be edited.

--- a/apps/web/docs/README.md
+++ b/apps/web/docs/README.md
@@ -1,0 +1,14 @@
+# Taskflow Web Docs
+
+Welcome to the documentation hub for the Convex-first Taskflow web app.
+
+## Contents
+
+- [Architecture](./architecture/README.md)
+- [Features](./features/README.md)
+
+## Quick Links
+
+- [Routes](./architecture/routing.md)
+- [Data model (Convex)](./architecture/data-model.md)
+- [Feature status](./features/status.md)

--- a/apps/web/docs/architecture/README.md
+++ b/apps/web/docs/architecture/README.md
@@ -1,0 +1,6 @@
+# Architecture
+
+This section captures how the web app is organized at a high level.
+
+- [Routing](./routing.md)
+- [Convex data model](./data-model.md)

--- a/apps/web/docs/architecture/data-model.md
+++ b/apps/web/docs/architecture/data-model.md
@@ -1,0 +1,51 @@
+# Convex Data Model
+
+The Taskflow web app is backed by Convex. The schema is defined in `convex/schema.ts` and includes auth tables plus Taskflow-specific entities.
+
+## Core Entities
+
+### User Profiles
+- **Table**: `userProfiles`
+- **Purpose**: Display identity info for the current user.
+- **Key fields**: `userId`, `firstName`, `lastName`, `email`.
+
+### User Preferences
+- **Table**: `userPreferences`
+- **Purpose**: Stores onboarding state and UX preferences.
+- **Key fields**: `defaultAIModel`, `onboardingCompletedAt`, `taskDefaultView`, `hideCompletedTasks`, `notificationsEnabled`.
+
+### Projects
+- **Table**: `projects`
+- **Purpose**: Group tasks and notes.
+- **Key fields**: `title`, `description`, `status`, `color`, `icon`, `createdAt`, `updatedAt`.
+
+### Tags
+- **Table**: `tags`
+- **Purpose**: Label tasks for filtering.
+- **Key fields**: `name`, `color`, `usageCount`, `createdAt`.
+
+### Tasks
+- **Table**: `tasks`
+- **Purpose**: Main work items with scheduling, status, and AI metadata.
+- **Key fields**: `title`, `description`, `status`, `priority`, `scheduledDate`, `dueDate`, `projectId`, `tagIds`, `parentTaskId`, `estimatedDuration`, `energyLevel`, `source`, `orderIndex`, `aiSummary`, `embedding`, `createdAt`, `updatedAt`.
+- **Indices**: per-user queries, scheduled/due views, search index on title.
+
+### Subtasks
+- **Table**: `subtasks`
+- **Purpose**: Checklist items nested under tasks.
+- **Key fields**: `taskId`, `title`, `isComplete`, `orderIndex`.
+
+### Inbox Items
+- **Table**: `inboxItems`
+- **Purpose**: Capture quick thoughts before converting to tasks/projects/notes.
+- **Key fields**: `content`, `status`, `labels`, `source`, `metadata`, `createdAt`, `updatedAt`.
+
+## AI Model Metadata
+
+### Base Models
+- **Table**: `baseModels`
+- **Purpose**: Keeps model identifiers for AI selection.
+
+### Available Models
+- **Table**: `availableModels`
+- **Purpose**: Stores model display info and pricing used by AI settings.

--- a/apps/web/docs/architecture/routing.md
+++ b/apps/web/docs/architecture/routing.md
@@ -1,0 +1,41 @@
+# Routing Map
+
+Taskflow Web uses the Next.js App Router. Routes fall into three groups:
+
+1. **Public marketing** (landing + roadmap)
+2. **Auth** (sign-in/sign-up)
+3. **App workspace** (inbox, tasks, projects, notes, chat, settings)
+
+## Public Routes
+
+| Route | Purpose | Data Source |
+| --- | --- | --- |
+| `/` | Marketing landing page | Static components |
+| `/roadmap` | Product roadmap | Static content |
+
+## Auth Routes
+
+| Route | Purpose | Data Source |
+| --- | --- | --- |
+| `/sign-in` | User sign-in | Convex Auth UI |
+| `/sign-up` | User sign-up | Convex Auth UI |
+
+## App Workspace Routes
+
+| Route | Purpose | Data Source |
+| --- | --- | --- |
+| `/app` | Redirects to tasks | Next.js redirect |
+| `/app/inbox` | Capture + triage inbox items | Convex (`inboxItems`) |
+| `/app/tasks` | Task board + filters + subtasks | Convex (`tasks`, `subtasks`, `tags`, `projects`) |
+| `/app/projects` | Project list, create/archive | Convex (`projects`) |
+| `/app/projects/[projectId]` | Project detail + task board | Convex (`projects`, `tasks`, `subtasks`, `tags`) |
+| `/app/notes` | Notes UI (project grouping, editor) | Local mock state |
+| `/app/chat` | AI chat landing | Local mock state |
+| `/app/chat/[threadId]` | AI chat conversation view | Local mock state |
+| `/app/settings` | Profile/preferences/AI settings | Convex (`userProfiles`, `userPreferences`) |
+| `/app/onboarding` | New user onboarding wizard | Convex (`userPreferences`) |
+
+## Route Layout Notes
+
+- `/app/chat` uses a shared chat shell layout that provides the left rail and dialog state.
+- `/app` routes are client components where data is fetched via `convex/react` hooks.

--- a/apps/web/docs/features/README.md
+++ b/apps/web/docs/features/README.md
@@ -1,0 +1,5 @@
+# Features
+
+This section tracks what is implemented today vs. what is still mocked or planned.
+
+- [Feature status](./status.md)

--- a/apps/web/docs/features/status.md
+++ b/apps/web/docs/features/status.md
@@ -1,0 +1,32 @@
+# Feature Status
+
+This snapshot reflects the current code in `apps/web`.
+
+## Core Workspace
+
+| Area | Status | Notes |
+| --- | --- | --- |
+| Inbox | ✅ Convex-backed | Capture, archive, delete, convert to task/project/note. |
+| Tasks | ✅ Convex-backed | Board + Today+ board, filters, subtasks, tags, scheduling, task details. |
+| Projects | ✅ Convex-backed | Create/edit/archive/delete projects; project detail view with task board. |
+| Notes | 🧪 UI-only | Notes list/editor uses local mock state and URL sync. |
+| AI Chat | 🧪 UI-only | Threads + messages powered by mock data; creates temp thread IDs. |
+
+## Onboarding & Settings
+
+| Area | Status | Notes |
+| --- | --- | --- |
+| Onboarding | ✅ Convex-backed | Writes preferences and onboarding completion. |
+| Settings | ✅ Convex-backed | Profile + preference management powered by Convex. |
+
+## Marketing
+
+| Area | Status | Notes |
+| --- | --- | --- |
+| Landing page | ✅ Implemented | Hero + workflow + feature panels. |
+| Roadmap | ✅ Implemented | Public roadmap view. |
+
+## Upcoming Integrations
+
+- Replace notes mock state with Convex persistence.
+- Connect AI chat to Convex conversations and AI actions.


### PR DESCRIPTION
### Motivation

- Provide a single-source reference for the current `apps/web` implementation and surface which areas are Convex-backed vs UI-only (mock state). 
- Capture routing, Convex data model, and feature status to help onboard contributors and guide next work (notes persistence and chat persistence). 
- Make the chat and notes UI specs reflect actual code paths and the current mock-data approach. 

### Description

- Added a documentation hub under `apps/web/docs/` with `architecture/` (routing, data model) and `features/status.md` to represent current feature coverage. 
- Updated `apps/web/README.md` to include a "Current Implementation Snapshot" and bumped the documented Node.js requirement to `25+`. 
- Updated UI specs to reflect the implemented mock-driven chat and notes behavior by editing `apps/web/AI_CHAT_UI_SPEC.md`, `apps/web/NOTES_UI_SPEC.md`, and `apps/web/PHASE1_COMPLETE.md` to document file-level implementation notes (e.g. `app/app/chat/components/chat-shell.tsx`, `app/app/chat/components/mock-data.ts`, and the notes page local state). 
- Rewrote `apps/web/convex/README.md` to summarize key Convex modules (`schema.ts`, `tasks.ts`, `projects.ts`, `inbox.ts`, `subtasks.ts`, `tags.ts`, `preferences.ts`, `profiles.ts`, `users.ts`, `auth.ts`) and added development notes for starting the Convex dev server and generated types. 

### Testing

- Ran the repository lint step with `npm run lint` (Turborepo runs lint across packages), which failed due to an `ESLint: Converting circular structure to JSON` error originating in `apps/frontend`'s ESLint configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69827f6464bc8321af5a75fadbd184ae)