### PR TITLE
Add notifications toggle to settings preferences

### DIFF
--- a/apps/web/components/settings/preferences-tab/preferences-tab.tsx
+++ b/apps/web/components/settings/preferences-tab/preferences-tab.tsx
@@ -64,6 +64,8 @@ export function PreferencesTab() {
   const [hideCompletedTasks, setHideCompletedTasks] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [isSavingHideCompleted, setIsSavingHideCompleted] = useState(false);
+  const [notificationsEnabled, setNotificationsEnabled] = useState(true);
+  const [isSavingNotifications, setIsSavingNotifications] = useState(false);
 
   const [newTagName, setNewTagName] = useState("");
   const [newTagColor, setNewTagColor] = useState("#6366f1");
@@ -104,6 +106,21 @@ export function PreferencesTab() {
       setHideCompletedTasks(savedValue);
     }
   }, [preferences?.hideCompletedTasks, hideCompletedTasks, isSavingHideCompleted]);
+
+  useEffect(() => {
+    const savedValue = preferences?.notificationsEnabled;
+    if (
+      savedValue !== undefined &&
+      savedValue !== notificationsEnabled &&
+      !isSavingNotifications
+    ) {
+      setNotificationsEnabled(savedValue);
+    }
+  }, [
+    preferences?.notificationsEnabled,
+    notificationsEnabled,
+    isSavingNotifications,
+  ]);
 
   // Initialize edit dialog state when tag changes
   useEffect(() => {
@@ -170,6 +187,21 @@ export function PreferencesTab() {
       console.error(error);
     } finally {
       setIsSavingHideCompleted(false);
+    }
+  };
+
+  const handleToggleNotifications = async (value: boolean) => {
+    setNotificationsEnabled(value);
+    setIsSavingNotifications(true);
+    try {
+      await updatePreferences({ notificationsEnabled: value });
+      toast.success("Notification preference updated");
+    } catch (error) {
+      toast.error("Failed to update notifications");
+      setNotificationsEnabled(!value);
+      console.error(error);
+    } finally {
+      setIsSavingNotifications(false);
     }
   };
 
@@ -426,6 +458,30 @@ export function PreferencesTab() {
                       onCheckedChange={handleToggleHideCompleted}
                       disabled={isSavingHideCompleted}
                       aria-label="Hide completed tasks"
+                    />
+                  )}
+                </div>
+              </Field>
+            </div>
+
+            <div className="pt-4 border-t">
+              <h3 className="text-sm font-medium mb-3">Notifications</h3>
+              <Field>
+                <div className="flex items-center justify-between gap-4">
+                  <div className="space-y-1">
+                    <FieldLabel>In-app notifications</FieldLabel>
+                    <FieldDescription>
+                      Toggle updates like successful saves or reminders
+                    </FieldDescription>
+                  </div>
+                  {isLoadingViewer ? (
+                    <Skeleton className="h-6 w-10" />
+                  ) : (
+                    <Switch
+                      checked={notificationsEnabled}
+                      onCheckedChange={handleToggleNotifications}
+                      disabled={isSavingNotifications}
+                      aria-label="Enable in-app notifications"
                     />
                   )}
                 </div>


### PR DESCRIPTION
### Motivation
- Expose an in-app notifications toggle in the Settings UI to match onboarding and let users enable/disable `notificationsEnabled` in their preferences.  
- Persist the preference using the existing `updatePreferences` mutation since the backend schema already includes `notificationsEnabled`.

### Description
- Added local state `notificationsEnabled` and `isSavingNotifications` and an effect to initialize the value from `preferences?.notificationsEnabled`.  
- Implemented `handleToggleNotifications` which updates the UI optimistically, calls `updatePreferences({ notificationsEnabled })`, and shows success/error `toast` messages.  
- Added a new `Notifications` section in `PreferencesTab` with a `Switch` wired to `notificationsEnabled`, showing a `Skeleton` while `isLoadingViewer` and disabling while saving.

### Testing
- Ran `npm run lint`, which failed due to an ESLint circular structure error in `@taskflow/frontend`.  
- Attempted `npm run dev:web`, which failed because `npm-run-all` was not found in the environment, preventing a local dev run of the UI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69827fce1598832182ada5b3a2b98409)