### PR TITLE
Add in-app notifications schema, sidebar item, and placeholder page

### DIFF
--- a/apps/web/app/app/notifications/page.tsx
+++ b/apps/web/app/app/notifications/page.tsx
@@ -1,0 +1,28 @@
+import { HugeiconsIcon } from "@hugeicons/react"
+import { NotificationIcon } from "@hugeicons/core-free-icons"
+
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty"
+
+export default function NotificationsPage() {
+  return (
+    <div className="flex h-full flex-col">
+      <Empty className="min-h-[320px]">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <HugeiconsIcon icon={NotificationIcon} className="size-4" />
+          </EmptyMedia>
+          <EmptyTitle>No notifications yet</EmptyTitle>
+          <EmptyDescription>
+            We will surface task updates and mentions here as they arrive.
+          </EmptyDescription>
+        </EmptyHeader>
+      </Empty>
+    </div>
+  )
+}

--- a/apps/web/components/app/app-shell.tsx
+++ b/apps/web/components/app/app-shell.tsx
@@ -14,6 +14,7 @@ import {
   Sun02Icon,
   Moon02Icon,
   InboxDownloadIcon,
+  NotificationIcon,
 } from "@hugeicons/core-free-icons";
 
 import { Button } from "@/components/ui/button";
@@ -42,6 +43,11 @@ const navItems = [
     title: "Inbox",
     href: "/app/inbox",
     icon: InboxDownloadIcon,
+  },
+  {
+    title: "Notifications",
+    href: "/app/notifications",
+    icon: NotificationIcon,
   },
   {
     title: "Tasks",

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -46,6 +46,28 @@ const schema = defineSchema({
     hideCompletedTasks: v.optional(v.boolean()),
     // Future: theme, notifications, privacy settings
   }).index("by_user", ["userId"]),
+  // In-app notifications
+  notifications: defineTable({
+    userId: v.id("users"), // Reference to auth user
+    type: v.string(), // Notification type identifier
+    title: v.string(), // Short title for the notification
+    body: v.optional(v.string()), // Optional details
+    data: v.optional(v.any()), // Flexible payload for deep links
+    status: v.union(
+      v.literal("unread"),
+      v.literal("read"),
+      v.literal("archived"),
+    ),
+    priority: v.optional(
+      v.union(v.literal("low"), v.literal("normal"), v.literal("high")),
+    ),
+    createdAt: v.number(),
+    readAt: v.optional(v.number()),
+    archivedAt: v.optional(v.number()),
+  })
+    .index("by_user", ["userId"])
+    .index("by_user_status", ["userId", "status"])
+    .index("by_user_createdAt", ["userId", "createdAt"]),
 
   // Projects - Task containers with status, color, icon
   projects: defineTable({


### PR DESCRIPTION
### Motivation
- Provide a foundation for in-app notifications so task updates and mentions can be surfaced to users.
- Add a minimal, in-app UI and navigation entry so the feature can be iterated on within the app.

### Description
- Add a `notifications` table to the Convex schema with fields for `userId`, `type`, `title`, `body`, `data`, `status`, `priority`, timestamps (`createdAt`, `readAt`, `archivedAt`) and indexes (`by_user`, `by_user_status`, `by_user_createdAt`).
- Add a placeholder notifications page at `apps/web/app/app/notifications/page.tsx` that renders the existing `Empty` empty-state component with a bell icon and messaging.
- Add a `Notifications` sidebar entry and import the `NotificationIcon` in `apps/web/components/app/app-shell.tsx` so the page is reachable from the main app navigation.

### Testing
- Ran `npm run lint` which failed due to an ESLint configuration error (circular structure) in `@taskflow/frontend` so lint did not complete successfully.
- Attempted `npm run dev:web` to start the web app which failed because `npm-run-all` is not available in the environment and the dev server did not start.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982810f8bdc83218fb4dda0fcb7d106)