### PR TITLE
Add App Router loading and error boundaries (shadcn route UI)

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -5,3 +5,15 @@ When working on Convex code, **always read `convex/_generated/ai/guidelines.md` 
 
 Convex agent skills for common tasks can be installed by running `npx convex ai-files install`.
 <!-- convex-ai-end -->
+
+## Route loading and errors (Next.js App Router)
+
+References: [Loading UI and Streaming](https://nextjs.org/docs/app/building-your-application/routing/loading-ui-and-streaming), [Error Handling](https://nextjs.org/docs/app/building-your-application/routing/error-handling).
+
+- **`loading.tsx`**: Wraps the **page** segment in Suspense (not the sibling `layout.tsx`). Instant fallback while the segment loads or streams.
+- **`error.tsx`**: Must be a **Client Component** (`"use client"`). Receives `error` and `reset()`. Does **not** catch errors thrown in the **same** segment’s `layout.tsx` — use a parent segment’s `error.tsx` for those.
+- **`global-error.tsx`**: Replaces the **root** `layout` when active; must include `<html>` and `<body>`. Our root fallback uses `components/route-ui/global-error.css` so it renders without `ThemeProvider`.
+
+Shared UI lives in `components/route-ui/`: `WorkspaceLoading`, `MarketingLoading`, `InspectorPanelLoading`, `AppRouteError`, `GlobalErrorFallback`.
+
+Route files: `app/loading.tsx`, `app/error.tsx`, `app/global-error.tsx`, `app/(auth)/loading.tsx`, `app/app/loading.tsx`, `app/app/error.tsx`, optional deeper `loading.tsx` under dynamic segments and `app/app/@right/loading.tsx` for the inspector parallel route.

--- a/apps/web/app/(auth)/loading.tsx
+++ b/apps/web/app/(auth)/loading.tsx
@@ -1,0 +1,5 @@
+import MarketingLoading from "@/components/route-ui/marketing-loading"
+
+export default function Loading() {
+  return <MarketingLoading />
+}

--- a/apps/web/app/app/@right/loading.tsx
+++ b/apps/web/app/app/@right/loading.tsx
@@ -1,0 +1,5 @@
+import InspectorPanelLoading from "@/components/route-ui/inspector-panel-loading"
+
+export default function Loading() {
+  return <InspectorPanelLoading />
+}

--- a/apps/web/app/app/chat/[threadId]/loading.tsx
+++ b/apps/web/app/app/chat/[threadId]/loading.tsx
@@ -1,0 +1,5 @@
+import WorkspaceLoading from "@/components/route-ui/workspace-loading"
+
+export default function Loading() {
+  return <WorkspaceLoading />
+}

--- a/apps/web/app/app/error.tsx
+++ b/apps/web/app/app/error.tsx
@@ -1,0 +1,8 @@
+"use client"
+
+import type { ComponentProps } from "react"
+import AppRouteError from "@/components/route-ui/app-route-error"
+
+export default function Error(props: ComponentProps<typeof AppRouteError>) {
+  return <AppRouteError {...props} />
+}

--- a/apps/web/app/app/loading.tsx
+++ b/apps/web/app/app/loading.tsx
@@ -1,0 +1,5 @@
+import WorkspaceLoading from "@/components/route-ui/workspace-loading"
+
+export default function Loading() {
+  return <WorkspaceLoading />
+}

--- a/apps/web/app/app/notes/[noteId]/loading.tsx
+++ b/apps/web/app/app/notes/[noteId]/loading.tsx
@@ -1,0 +1,5 @@
+import WorkspaceLoading from "@/components/route-ui/workspace-loading"
+
+export default function Loading() {
+  return <WorkspaceLoading />
+}

--- a/apps/web/app/app/projects/[projectId]/loading.tsx
+++ b/apps/web/app/app/projects/[projectId]/loading.tsx
@@ -1,0 +1,5 @@
+import WorkspaceLoading from "@/components/route-ui/workspace-loading"
+
+export default function Loading() {
+  return <WorkspaceLoading />
+}

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -1,0 +1,10 @@
+"use client"
+
+import type { ComponentProps } from "react"
+import AppRouteError from "@/components/route-ui/app-route-error"
+
+export default function Error(props: ComponentProps<typeof AppRouteError>) {
+  return (
+    <AppRouteError {...props} homeHref="/" homeLabel="Back to home" />
+  )
+}

--- a/apps/web/app/global-error.tsx
+++ b/apps/web/app/global-error.tsx
@@ -1,0 +1,17 @@
+"use client"
+
+import GlobalErrorFallback from "@/components/route-ui/global-error-fallback"
+
+/**
+ * Root-level error boundary — replaces the root layout when active.
+ * @see https://nextjs.org/docs/app/building-your-application/routing/error-handling
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return <GlobalErrorFallback error={error} reset={reset} />
+}

--- a/apps/web/app/loading.tsx
+++ b/apps/web/app/loading.tsx
@@ -1,0 +1,5 @@
+import MarketingLoading from "@/components/route-ui/marketing-loading"
+
+export default function Loading() {
+  return <MarketingLoading />
+}

--- a/apps/web/app/roadmap/loading.tsx
+++ b/apps/web/app/roadmap/loading.tsx
@@ -1,0 +1,5 @@
+import MarketingLoading from "@/components/route-ui/marketing-loading"
+
+export default function Loading() {
+  return <MarketingLoading />
+}

--- a/apps/web/components/route-ui/app-route-error.tsx
+++ b/apps/web/components/route-ui/app-route-error.tsx
@@ -1,0 +1,73 @@
+"use client"
+
+import Link from "next/link"
+import { useEffect } from "react"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { AlertCircleIcon } from "@hugeicons/core-free-icons"
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty"
+
+/**
+ * App Router `error.tsx` boundary — must be a Client Component.
+ * @see https://nextjs.org/docs/app/building-your-application/routing/error-handling
+ */
+export default function AppRouteError({
+  error,
+  reset,
+  homeHref = "/app/tasks",
+  homeLabel = "Back to app",
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+  /** Root layout uses `/`; authenticated app uses `/app/tasks`. */
+  homeHref?: string
+  homeLabel?: string
+}) {
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col items-center justify-center p-4">
+      <Empty className="max-w-md border-border/60 bg-card/30">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <HugeiconsIcon
+              icon={AlertCircleIcon}
+              className="size-4 text-destructive"
+              strokeWidth={2}
+            />
+          </EmptyMedia>
+          <EmptyTitle>Something went wrong</EmptyTitle>
+          <EmptyDescription>
+            This page hit an unexpected error. You can try again or return to
+            the app home.
+          </EmptyDescription>
+        </EmptyHeader>
+        <Alert variant="destructive" className="text-left">
+          <AlertTitle className="text-xs">Error</AlertTitle>
+          <AlertDescription className="font-mono text-[11px] break-all">
+            {error.message || "Unknown error"}
+            {error.digest ? ` (digest: ${error.digest})` : ""}
+          </AlertDescription>
+        </Alert>
+        <div className="flex w-full flex-wrap gap-2">
+          <Button type="button" size="sm" onClick={() => reset()}>
+            Try again
+          </Button>
+          <Button type="button" size="sm" variant="outline" asChild>
+            <Link href={homeHref}>{homeLabel}</Link>
+          </Button>
+        </div>
+      </Empty>
+    </div>
+  )
+}

--- a/apps/web/components/route-ui/global-error-fallback.tsx
+++ b/apps/web/components/route-ui/global-error-fallback.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import "./global-error.css"
+
+/**
+ * Root `global-error.tsx` UI — rendered outside the root layout, so it cannot
+ * use `ThemeProvider` or most app providers. Styles: `global-error.css` (mirrors
+ * critical tokens from `globals.css` for light/dark via `prefers-color-scheme`).
+ */
+export default function GlobalErrorFallback({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <html lang="en">
+      <body className="global-error-body">
+        <div className="global-error-root">
+          <h1 className="global-error-title">Something went wrong</h1>
+          <p className="global-error-desc">
+            Taskflow hit a critical error. You can try reloading this page.
+          </p>
+          {error.message ? (
+            <pre className="global-error-pre">{error.message}</pre>
+          ) : null}
+          <button type="button" className="global-error-button" onClick={reset}>
+            Try again
+          </button>
+        </div>
+      </body>
+    </html>
+  )
+}

--- a/apps/web/components/route-ui/global-error.css
+++ b/apps/web/components/route-ui/global-error.css
@@ -1,0 +1,91 @@
+/* Minimal styles for `global-error.tsx` — runs without root layout / ThemeProvider */
+
+.global-error-body {
+  margin: 0;
+  min-height: 100dvh;
+  font-family:
+    ui-sans-serif,
+    system-ui,
+    sans-serif;
+  background: oklch(0.99 0 0);
+  color: oklch(0 0 0);
+}
+
+@media (prefers-color-scheme: dark) {
+  .global-error-body {
+    background: oklch(0.1776 0 0);
+    color: oklch(0.9821 0 0);
+  }
+}
+
+.global-error-root {
+  display: flex;
+  min-height: 100dvh;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 1.5rem;
+  text-align: center;
+}
+
+.global-error-title {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.global-error-desc {
+  margin: 0;
+  max-width: 28rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  opacity: 0.75;
+}
+
+.global-error-pre {
+  max-width: 36rem;
+  overflow: auto;
+  border-radius: 0.375rem;
+  border: 1px solid oklch(0.92 0 0);
+  background: oklch(0.97 0 0);
+  padding: 0.75rem;
+  font-size: 0.75rem;
+  text-align: left;
+  color: oklch(0.35 0 0);
+}
+
+@media (prefers-color-scheme: dark) {
+  .global-error-pre {
+    border-color: oklch(0.32 0 0);
+    background: oklch(0.22 0 0);
+    color: oklch(0.85 0 0);
+  }
+}
+
+.global-error-button {
+  cursor: pointer;
+  border-radius: 0.375rem;
+  border: 1px solid transparent;
+  background: oklch(0.3163 0.019 63.7);
+  padding: 0.5rem 1rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: oklch(1 0 0);
+}
+
+.global-error-button:hover {
+  opacity: 0.9;
+}
+
+.global-error-button:focus-visible {
+  outline: 2px solid oklch(0 0 0);
+  outline-offset: 2px;
+}
+
+@media (prefers-color-scheme: dark) {
+  .global-error-button:focus-visible {
+    outline-color: oklch(0.95 0 0);
+  }
+}

--- a/apps/web/components/route-ui/inspector-panel-loading.tsx
+++ b/apps/web/components/route-ui/inspector-panel-loading.tsx
@@ -1,0 +1,28 @@
+import { Skeleton } from "@/components/ui/skeleton"
+import { Spinner } from "@/components/ui/spinner"
+import { cn } from "@/lib/utils"
+
+/** Loading UI for parallel `@right` inspector slots (chat / notes dossier). */
+export default function InspectorPanelLoading({
+  className,
+}: {
+  className?: string
+}) {
+  return (
+    <div
+      className={cn(
+        "flex min-h-0 flex-1 flex-col gap-3 overflow-hidden p-4 pt-3",
+        className,
+      )}
+      aria-busy="true"
+      aria-label="Loading panel"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <Skeleton className="h-5 w-24" />
+        <Spinner className="size-4 shrink-0 text-muted-foreground" />
+      </div>
+      <Skeleton className="min-h-[120px] w-full flex-1 rounded-lg" />
+      <Skeleton className="h-8 w-full" />
+    </div>
+  )
+}

--- a/apps/web/components/route-ui/marketing-loading.tsx
+++ b/apps/web/components/route-ui/marketing-loading.tsx
@@ -1,0 +1,23 @@
+import { Spinner } from "@/components/ui/spinner"
+import { cn } from "@/lib/utils"
+
+/** Minimal loading UI for public / marketing routes. */
+export default function MarketingLoading({
+  className,
+}: {
+  className?: string
+}) {
+  return (
+    <div
+      className={cn(
+        "flex min-h-dvh flex-col items-center justify-center gap-3 bg-background",
+        className,
+      )}
+      aria-busy="true"
+      aria-label="Loading"
+    >
+      <Spinner className="size-5 text-muted-foreground" />
+      <p className="text-xs text-muted-foreground">Loading…</p>
+    </div>
+  )
+}

--- a/apps/web/components/route-ui/workspace-loading.tsx
+++ b/apps/web/components/route-ui/workspace-loading.tsx
@@ -1,0 +1,45 @@
+import { Skeleton } from "@/components/ui/skeleton"
+import { Spinner } from "@/components/ui/spinner"
+import { cn } from "@/lib/utils"
+
+/**
+ * Default loading UI for authenticated workspace routes (`/app/*`).
+ * Server Component — used from route `loading.tsx` files (Suspense fallback).
+ */
+export default function WorkspaceLoading({
+  className,
+}: {
+  className?: string
+}) {
+  return (
+    <div
+      className={cn(
+        "flex min-h-0 flex-1 flex-col gap-3 overflow-hidden p-2 md:p-2",
+        className,
+      )}
+      aria-busy="true"
+      aria-label="Loading"
+    >
+      <div className="flex shrink-0 items-center justify-between gap-2">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <Skeleton className="h-8 w-28" />
+          <Skeleton className="h-8 w-20" />
+        </div>
+        <Spinner className="size-4 shrink-0 text-muted-foreground" />
+      </div>
+      <div className="grid min-h-0 flex-1 gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,2fr)]">
+        <div className="flex min-h-[200px] flex-col gap-2 rounded-lg border border-border/60 bg-muted/20 p-3">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+        </div>
+        <div className="flex min-h-[200px] flex-col gap-2 rounded-lg border border-border/60 bg-muted/20 p-3">
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="min-h-[120px] w-full flex-1" />
+          <Skeleton className="h-9 w-full max-w-md" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/docs/features/README.md
+++ b/apps/web/docs/features/README.md
@@ -4,6 +4,7 @@ This section documents current product behavior in `apps/web`.
 
 ## Core Workspace
 
+- [App shell and layout PRD](./layout-shell-prd.md) (planned improvements)
 - [Feature Status](./status.md)
 - [Inbox](./inbox.md)
 - [Tasks](./tasks.md)

--- a/apps/web/docs/features/layout-shell-prd.md
+++ b/apps/web/docs/features/layout-shell-prd.md
@@ -1,0 +1,129 @@
+# App shell and layout PRD
+
+## Problem Statement
+
+Taskflow’s signed-in experience is built around `AppShell` (`components/app/app-shell.tsx`): a primary sidebar, a central work area, and—on Chat and Notes routes—a right-hand inspector fed by the `@right` parallel route. The architecture is strong (auth gate, overflow discipline, parallel inspector URLs), but several behaviors reduce clarity and comfort for daily use.
+
+Users must infer **when the inspector exists**, **how to return to thread or note lists** without a conventional navigation click, and **how wide each column is allowed to be**. Mobile and desktop chrome differ between Chat and other routes. Power users lack **resize persistence** and **keyboard-first** flows for the two side regions. New users face a **three-band mental model** (primary rail, main, dossier) without always seeing affordances that explain it.
+
+This PRD defines a cohesive upgrade to the workspace layout so navigation, context panels, and focus states feel intentional, consistent, and learnable—without rewriting routing or abandoning the parallel `@right` model.
+
+## Goals
+
+1. **Orientation:** Users always understand which region is active (navigation, work, context) and how to move between them on keyboard, pointer, and touch.
+2. **Consistency:** Top-level chrome (titles, primary actions, inspector access) follows one pattern across Chat, Notes, Tasks, Projects, Inbox, and Settings where applicable.
+3. **Control:** Users can adjust primary and inspector widths within safe bounds, with optional persistence per device class.
+4. **Discoverability:** Inspector and contextual sidebars expose clear entry points when they have content; empty states explain what will appear there.
+5. **Accessibility:** Focus order, labels, and shortcuts for opening, closing, and resizing panels meet WCAG-oriented expectations for keyboard and screen-reader users.
+
+## Non-goals
+
+- Replacing Next.js App Router or removing the `@right` parallel route for Chat and Notes.
+- Redesigning feature-specific content inside Tasks, Projects, or the AI chat transcript (except where layout chrome touches them).
+- Building a full IDE-style multi-pane system (terminals, file trees) in this initiative.
+- Changing authentication or onboarding business rules beyond layout surfaces.
+
+## Current state (summary)
+
+- **Root layout:** Theme, fonts, Convex, toasts (`app/layout.tsx`).
+- **App layout:** Server auth check; passes `children` + `right` into `AppShell` (`app/app/layout.tsx`).
+- **AppShell:** `SidebarProvider` with `primary` and `inspector` scopes; left rail swaps between workspace nav, `ChatSidebar`, and `NotesAppSidebar`; right inspector is offcanvas with route-dependent width; onboarding gate redirects incomplete users.
+- **Chat / Notes:** Extra client layouts (`chat/layout.tsx`, `notes` + `NotesShell`) handle mobile headers and list/detail behavior.
+
+## User problems (evidence-based)
+
+| Problem | Impact |
+|--------|--------|
+| Inspector defaults closed; entry points differ by breakpoint | Users miss dossier/context content on desktop. |
+| Re-clicking “AI Chat” / “Notes” toggles list mode instead of navigating | Efficient for power users, opaque for new users. |
+| Fixed sidebar widths | Cramped on small laptops; wasted space on ultrawide. |
+| Mixed mobile chrome (generic sticky bar vs Chat-specific header) | App feels like multiple products, not one shell. |
+| Three vertical bands without a unified label system | Higher cognitive load when Chat + inspector are both relevant. |
+
+## Proposed solution (phased)
+
+### Phase 1 — Shell clarity and consistency
+
+- Define a **small set of layout modes** documented in UI copy: e.g. “Workspace” (primary nav visible), “Context list” (Chat threads or Notes list in the primary column), “Focus” (optional future: hide rails).
+- Add **explicit controls** to switch between workspace nav and Chat/Notes list modes (in addition to re-clicking nav items), with tooltips for first-time education.
+- Unify **page header patterns** where possible: title row, optional subtitle, slot for route actions, consistent inspector button placement.
+- **Inspector affordance:** When `@right` has meaningful content for the current URL, show a persistent control (e.g. “Dossier” / “Inspector” button or icon) in the shared header; when empty, show a muted state or hide per route rules.
+- Align **mobile** sticky regions: one spec for title height, safe-area padding, and action placement across Chat and non-chat routes.
+
+### Phase 2 — Resizable and persistent layout
+
+- Introduce **resizable split** between `SidebarInset` main column and the inspector (and optionally primary sidebar width) using bounded min/max widths.
+- Persist widths with **`localStorage` or equivalent** (respect reduced-motion and privacy: no server sync required in v1).
+- Ensure **keyboard** resize or collapse: document shortcuts; pair with `SidebarTrigger` behavior.
+
+### Phase 3 — Polish and performance
+
+- Loading states use **skeletons** that mirror the three-column shell (`components/route-ui/` alignment).
+- Audit **focus traps** when inspector opens as offcanvas on mobile.
+- Optional: **remember inspector open/closed** per route family (chat vs notes) with sensible defaults.
+
+## User stories
+
+1. As a new user, I want the app to explain what the right panel is for on Chat and Notes, so I am not surprised when it is empty or full.
+2. As a user, I want a visible way to open the inspector when it has content, so I do not have to discover the control by accident.
+3. As a user, I want to switch between global navigation and Chat threads (or Notes) with an obvious control, so I do not rely only on repeating the same sidebar link.
+4. As a Chat user, I want the top bar to behave like the rest of the app on mobile, so I do not relearn patterns per feature.
+5. As a power user, I want to resize the main column and inspector, so I can read long threads and side context comfortably.
+6. As a returning user, I want my panel widths remembered, so I do not resize every session.
+7. As a keyboard user, I want shortcuts to toggle primary sidebar and inspector, so I can work without the mouse.
+8. As a screen-reader user, I want regions labeled (navigation, main, complementary), so I can move predictably through the shell.
+
+## Success metrics
+
+- **Activation:** Increased rate of inspector opens on Chat/Notes sessions where dossier content is available (instrumented event).
+- **Efficiency:** Reduction in repeated navigations that only exist to “find” the thread list (proxy: fewer duplicate `/app/chat` loads in a session).
+- **Satisfaction:** Task-completion surveys or in-app feedback on “layout is easy to understand” (baseline vs after Phase 1).
+- **Technical:** No regression in LCP for `/app/tasks` and `/app/chat`; sidebar resize does not cause layout thrash on low-end devices.
+
+## Functional requirements
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| F1 | Shared header component or spec for app routes (title, actions, inspector entry) | P0 |
+| F2 | Explicit control + tooltip for Chat/Notes “back to list” vs “workspace nav” modes | P0 |
+| F3 | Inspector entry visible when route has dossier content; empty-state copy when not | P0 |
+| F4 | Resizable primary and/or inspector widths with min/max | P1 |
+| F5 | Persisted panel widths (local only) | P1 |
+| F6 | Documented keyboard shortcuts for sidebar and inspector | P1 |
+| F7 | Region semantics (`nav`, `main`, `complementary`) and focus order audit | P1 |
+| F8 | Loading skeletons aligned to shell columns | P2 |
+
+## Design and engineering notes
+
+- **Components:** Prefer extending `components/ui/sidebar` and existing shadcn primitives; avoid one-off layout systems.
+- **Motion:** Respect `prefers-reduced-motion`; inspector animations already use `useReducedMotion` in `InspectorPanelContent`—keep parity for new transitions.
+- **Breakpoints:** `md:` behavior for Notes list/detail (`NotesShell`) must remain coherent with any header unification.
+- **Parallel routes:** Keep `@right` as the source of inspector content; resizing is a presentation concern around the same slots.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Resize handles clutter touch UI | Show drag affordance on desktop; keep touch as swipe/offcanvas only on narrow breakpoints. |
+| Persisted widths break small windows | Clamp on load; reset if viewport smaller than min sum of panels. |
+| Header unification breaks Chat-specific actions | Use a flexible action slot; Chat keeps composer-adjacent actions in main, not header, if that is today’s pattern. |
+
+## Out of scope (this PRD)
+
+- New features in dossier/inspector content (only how it is opened and sized).
+- Changing AI Chat or Notes data models.
+- Full redesign of marketing or auth pages.
+- Third-party window-tiling or multi-window support.
+
+## Open questions
+
+1. Should inspector open automatically on first visit to a thread/note detail, or only on explicit user action?
+2. Should primary sidebar width be user-resizable, or only the inspector?
+3. Do we standardize on one mobile header component for all `/app/*` routes in Phase 1, or only Chat + default shell?
+
+## References
+
+- Next.js App Router — [Parallel Routes](https://nextjs.org/docs/app/building-your-application/routing/parallel-routes)
+- Existing shell implementation: `apps/web/components/app/app-shell.tsx`
+- App layout and `@right` slot: `apps/web/app/app/layout.tsx`
+- Related UI docs: `apps/web/docs/ui-guidelines.md`, `apps/web/docs/architecture/routing.md`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Next.js App Router `loading.tsx` and `error.tsx` files that were missing, using the existing shadcn-based design system (`Skeleton`, `Spinner`, `Empty`, `Alert`, `Button`) via shared components under `components/route-ui/`.

## Docs

Aligned with current Next.js App Router behavior:

- **Loading UI and Streaming**: https://nextjs.org/docs/app/building-your-application/routing/loading-ui-and-streaming — `loading.js` wraps the **page** in Suspense (not the sibling layout).
- **Error Handling**: https://nextjs.org/docs/app/building-your-application/routing/error-handling — `error.js` must be a Client Component with `error` and `reset`; it does not catch errors in the **same** segment’s `layout.js`. **`global-error.js`** replaces the root layout and must define `<html>` / `<body>`.

Project notes were added to `apps/web/AGENTS.md`.

## What was added

- **`app/loading.tsx`** — marketing-style fallback for `/`, `/roadmap`, etc.
- **`app/(auth)/loading.tsx`** — same for sign-in/up.
- **`app/error.tsx`** — public error boundary (links home).
- **`app/global-error.tsx`** — critical errors; minimal CSS in `global-error.css` (no root `ThemeProvider`).
- **`app/app/loading.tsx`** + **`app/app/error.tsx`** — authenticated workspace shell.
- Optional deeper **`loading.tsx`** for dynamic routes and **`app/app/@right/loading.tsx`** for the inspector parallel route.

## Caveat

`loading.tsx` helps most when a route segment **suspends** (async Server Components or lazy chunks). Many `/app/*` **pages** are fully client (`"use client"`), so the skeleton may appear briefly on first navigation or code-split boundaries—not as a replacement for Convex loading states.

## Lint

Targeted eslint on new files passes. Full `npm run lint` still reports pre-existing issues elsewhere in the repo.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6589d328-22cc-4a68-99fb-46929a79494b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6589d328-22cc-4a68-99fb-46929a79494b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

